### PR TITLE
Update db schema

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,8 +1,7 @@
 class CollectionsController < ApplicationController
   def index
-
-    @vinyls_to_exchange = CollectionVinyl.user_to_exchange(current_user)
-    @collections = Collection.where(user: current_user)
+    @vinyls_to_exchange = current_user.vinyls_to_exchange
+    @collections = current_user.collections
   end
 
   def show

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -3,7 +3,6 @@ class CollectionsController < ApplicationController
 
     @vinyls_to_exchange = CollectionVinyl.user_to_exchange(current_user)
     @collections = Collection.where(user: current_user)
-
   end
 
   def show

--- a/app/controllers/exchanges_controller.rb
+++ b/app/controllers/exchanges_controller.rb
@@ -16,12 +16,8 @@ class ExchangesController < ApplicationController
   end
 
   def new
-    # collections = current_user.collections
-    # @collections_vinyls = CollectionVinyl.where(collection: collections)
     @users_vinyls_to_offer = current_user.users_vinyls_to_exchange.includes(:vinyl)
-
     @requested_vinyl = UsersVinyl.find(params[:users_vinyl_id])
-    # @exchange = Exchange.new(requested_vinyl_id: params[:collections_vinyl_id], user: current_user, status: :pending)
     @exchange = Exchange.new
   end
 

--- a/app/controllers/exchanges_controller.rb
+++ b/app/controllers/exchanges_controller.rb
@@ -1,15 +1,13 @@
 class ExchangesController < ApplicationController
   def index
-    @exchanges = Exchange.where(user: current_user)
-
-    # @exchange = Exchange.where(requested_vinyl_id: )
+    @exchanges = current_user.exchanges
   end
 
   def create
-    exchange = Exchange.new(requested_vinyl_id: params[:collections_vinyl_id], user: current_user, status: :pending)
+    exchange = Exchange.new(requested_vinyl_id: params[:users_vinyl_id], user: current_user, status: :pending)
     exchange.save!
     params[:collection_vinyl_ids].each do |cvid|
-      offered_vinyls = OfferedVinyl.new(exchange: exchange, collection_vinyl_id: cvid)
+      offered_vinyls = OfferedVinyl.new(exchange: exchange, users_vinyl_id: cvid)
       offered_vinyls.save!
     end
     redirect_to my_exchanges_path
@@ -18,10 +16,11 @@ class ExchangesController < ApplicationController
   end
 
   def new
-    collections = current_user.collections
-    @collections_vinyls = CollectionVinyl.where(collection: collections)
+    # collections = current_user.collections
+    # @collections_vinyls = CollectionVinyl.where(collection: collections)
+    @users_vinyls_to_offer = current_user.users_vinyls_to_exchange.includes(:vinyl)
 
-    @requested_vinyl = CollectionVinyl.find(params[:collections_vinyl_id])
+    @requested_vinyl = UsersVinyl.find(params[:users_vinyl_id])
     # @exchange = Exchange.new(requested_vinyl_id: params[:collections_vinyl_id], user: current_user, status: :pending)
     @exchange = Exchange.new
   end

--- a/app/controllers/vinyls_controller.rb
+++ b/app/controllers/vinyls_controller.rb
@@ -11,7 +11,7 @@ class VinylsController < ApplicationController
 
   def show
     @vinyl = Vinyl.find(params[:id])
-    @collections_vinyls = CollectionVinyl.where(vinyl: @vinyl).where(offer_for_trade: true)
+    @users_vinyls = UsersVinyl.where(vinyl: @vinyl).where(offer_for_trade: true)
 
     # collections = collections_vinyls.map do |collection_vinyl|
     #   collection_vinyl.collection

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,7 +1,8 @@
 class Collection < ApplicationRecord
   belongs_to :user
-  has_many :collection_vinyls
-  has_many :vinyls, through: :collection_vinyls
+  has_many :collections_vinyls
+  has_many :users_vinyls, through: :collections_vinyls
+  has_many :vinyls, through: :users_vinyls
   has_one_attached :photo
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/collection_vinyl.rb
+++ b/app/models/collection_vinyl.rb
@@ -1,7 +1,0 @@
-class CollectionVinyl < ApplicationRecord
-  scope :user_to_exchange, ->(user) { joins(collection: :user).where(offer_for_trade: true).where(users: { id: user.id })}
-
-  belongs_to :vinyl
-  belongs_to :collection
-  has_one :user, through: :collection
-end

--- a/app/models/collections_vinyl.rb
+++ b/app/models/collections_vinyl.rb
@@ -1,0 +1,7 @@
+class CollectionsVinyl < ApplicationRecord
+  # scope :user_to_exchange, ->(user) { joins(collection: :user).where(offer_for_trade: true).where(users: { id: user.id })}
+
+  belongs_to :collection
+  belongs_to :users_vinyl
+  # has_one :user, through: :collection
+end

--- a/app/models/collections_vinyl.rb
+++ b/app/models/collections_vinyl.rb
@@ -1,7 +1,4 @@
 class CollectionsVinyl < ApplicationRecord
-  # scope :user_to_exchange, ->(user) { joins(collection: :user).where(offer_for_trade: true).where(users: { id: user.id })}
-
   belongs_to :collection
   belongs_to :users_vinyl
-  # has_one :user, through: :collection
 end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -1,10 +1,10 @@
 class Exchange < ApplicationRecord
   belongs_to :user
-  belongs_to :requested_vinyl, class_name: "CollectionVinyl", foreign_key: :requested_vinyl_id, optional: true
-  belongs_to :offered_vinyl, class_name: "CollectionVinyl", foreign_key: :offered_vinyl_id, optional: true
+  belongs_to :requested_vinyl, class_name: "UsersVinyl", foreign_key: :requested_vinyl_id
   has_many :offered_vinyls
-  has_many :collections_vinyls, through: :offered_vinyls
-  has_many :vinyls, through: :collections_vinyls
+  # belongs_to :offered_vinyl, class_name: "CollectionVinyl", foreign_key: :offered_vinyl_id, optional: true
+  # has_many :collections_vinyls, through: :offered_vinyls
+  # has_many :vinyls, through: :collections_vinyls
   enum status: {
     pending: 0,
     Confirmed: 1,

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -2,9 +2,7 @@ class Exchange < ApplicationRecord
   belongs_to :user
   belongs_to :requested_vinyl, class_name: "UsersVinyl", foreign_key: :requested_vinyl_id
   has_many :offered_vinyls
-  # belongs_to :offered_vinyl, class_name: "CollectionVinyl", foreign_key: :offered_vinyl_id, optional: true
-  # has_many :collections_vinyls, through: :offered_vinyls
-  # has_many :vinyls, through: :collections_vinyls
+
   enum status: {
     pending: 0,
     Confirmed: 1,

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,4 +1,3 @@
 class Genre < ApplicationRecord
-
-    validates :name, presence: true
+  validates :name, presence: true
 end

--- a/app/models/offered_vinyl.rb
+++ b/app/models/offered_vinyl.rb
@@ -1,4 +1,4 @@
 class OfferedVinyl < ApplicationRecord
   belongs_to :exchange
-  belongs_to :collection_vinyl
+  belongs_to :users_vinyl
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,16 @@
 class User < ApplicationRecord
   has_many :wishlists
   has_many :collections
-  has_many :collections_vinyls, through: :collections
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :users_vinyls
+  has_many :vinyls, through: :users_vinyls
+  has_many :exchanges
+
+  # has_many :collections_vinyls, through: :collections
 
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,11 +7,16 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :users_vinyls
+  has_many :users_vinyls_to_exchange, -> { where offer_for_trade: true }, class_name: 'UsersVinyl', foreign_key: :user_id
   has_many :vinyls, through: :users_vinyls
+  has_many :vinyls_to_exchange, through: :users_vinyls_to_exchange, class_name: 'Vinyl', source: :vinyl
+
   has_many :exchanges
 
   # has_many :collections_vinyls, through: :collections
 
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?
+
+  # scope :vinyls_to_exchange, -> { joins(users_vinyls: :vinyls).where(offer_for_trade: true).where(users: { id: user.id })}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,10 +13,6 @@ class User < ApplicationRecord
 
   has_many :exchanges
 
-  # has_many :collections_vinyls, through: :collections
-
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?
-
-  # scope :vinyls_to_exchange, -> { joins(users_vinyls: :vinyls).where(offer_for_trade: true).where(users: { id: user.id })}
 end

--- a/app/models/users_vinyl.rb
+++ b/app/models/users_vinyl.rb
@@ -1,0 +1,4 @@
+class UsersVinyl < ApplicationRecord
+  belongs_to :user
+  belongs_to :vinyl
+end

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -28,10 +28,10 @@
       <% @vinyls_to_exchange.each do |to_exchange| %>
       <div class="col">
         <div class="card shadow p-3">
-          <p> <%= image_tag (to_exchange.vinyl.photo_url), class:"card-img-top rouded" %></p>
+          <p> <%= image_tag (to_exchange.photo_url), class:"card-img-top rouded" %></p>
           <div class="card-body">
-          <h5 class="card-title"><%= to_exchange.vinyl.title%>(<%=to_exchange.vinyl.year%>)</h5>
-          <p><%= to_exchange.vinyl.artist.name%></p>
+          <h5 class="card-title"><%= to_exchange.title%>(<%=to_exchange.year%>)</h5>
+          <p><%= to_exchange.artist.name%></p>
           </div>
         </div>
       </div>

--- a/app/views/exchanges/index.html.erb
+++ b/app/views/exchanges/index.html.erb
@@ -9,8 +9,8 @@
       <li>
         <div class="d-flex flex-column p-2">
           <%= image_tag exchange.requested_vinyl.vinyl.photo_url, class:"vinyl_image" unless exchange.requested_vinyl.nil?%>
-          <p><%= exchange.requested_vinyl.vinyl.title unless exchange.requested_vinyl.nil?%></p>
-          <p><%= exchange.requested_vinyl.vinyl.year unless exchange.requested_vinyl.nil?%></p>
+          <p><%= exchange.requested_vinyl.vinyl.title %></p>
+          <p><%= exchange.requested_vinyl.vinyl.year %></p>
         </div>
         <div class="d-flex flex-column p-2">
           <% exchange.offered_vinyls.each do |offered_vinyl| %>

--- a/app/views/exchanges/index.html.erb
+++ b/app/views/exchanges/index.html.erb
@@ -4,22 +4,26 @@
       <h4>Mon vinyle</h4>
     </div>
   <div class="d-flex justify-content-between">
-    <% @exchanges.each do |exchange| %>
-    <div class="d-flex flex-column p-2">
-      <%= image_tag exchange.requested_vinyl.vinyl.photo_url, class:"vinyl_image" unless exchange.requested_vinyl.nil?%>
-      <p><%= exchange.requested_vinyl.vinyl.title unless exchange.requested_vinyl.nil?%></p>
-      <p><%= exchange.requested_vinyl.vinyl.year unless exchange.requested_vinyl.nil?%></p>
-    </div>
-    <div class="d-flex flex-column p-2">
-      <% exchange.offered_vinyls.each do |exchange_offer| %>
-      <div class="d-flex flex-column p-2">
-        <%= image_tag exchange_offer.collection_vinyl.vinyl.photo_url, class:"vinyl_image" unless exchange.requested_vinyl.nil?%>
-        <p><%= exchange_offer.collection_vinyl.vinyl.title unless exchange.requested_vinyl.nil?%></p>
-        <p><%= exchange_offer.collection_vinyl.vinyl.year unless exchange.requested_vinyl.nil?%></p>
-      </div>
-      <% end %>
-    </div>
-    <%end%>
+    <ul>
+      <% @exchanges.each do |exchange| %>
+      <li>
+        <div class="d-flex flex-column p-2">
+          <%= image_tag exchange.requested_vinyl.vinyl.photo_url, class:"vinyl_image" unless exchange.requested_vinyl.nil?%>
+          <p><%= exchange.requested_vinyl.vinyl.title unless exchange.requested_vinyl.nil?%></p>
+          <p><%= exchange.requested_vinyl.vinyl.year unless exchange.requested_vinyl.nil?%></p>
+        </div>
+        <div class="d-flex flex-column p-2">
+          <% exchange.offered_vinyls.each do |offered_vinyl| %>
+          <div class="d-flex flex-column p-2">
+            <%= image_tag offered_vinyl.users_vinyl.vinyl.photo_url, class:"vinyl_image" unless exchange.requested_vinyl.nil?%>
+            <p><%= offered_vinyl.users_vinyl.vinyl.title %></p>
+            <p><%= offered_vinyl.users_vinyl.vinyl.year %></p>
+          </div>
+          <% end %>
+        </div>
+      </li>
+      <%end%>
+    </ul>
   </div>
 <%= link_to "Valider", my_exchanges_path ,class: "btn-btn-dark" %>
 

--- a/app/views/exchanges/new.html.erb
+++ b/app/views/exchanges/new.html.erb
@@ -1,12 +1,12 @@
 <h2>Choisis le(s) vinyle(s) en échange</h2>
-<%= simple_form_for([@requested_vinyl, @exchange],url: collections_vinyl_exchanges_path ) do |v| %>
+<%= simple_form_for([@requested_vinyl, @exchange]) do |v| %>
 
-<% @collections_vinyls.each do |cv| %>
+<% @users_vinyls_to_offer.each do |users_vinyl| %>
   <label>
-    <input type="checkbox" name="collection_vinyl_ids[]" value="<%= cv.id %>">
-    <%= cv.vinyl.title%>
-    <%= cv.vinyl.year %>
-    <%= image_tag cv.vinyl.photo_url %>
+    <input type="checkbox" name="collection_vinyl_ids[]" value="<%= users_vinyl.id %>">
+    <%= users_vinyl.vinyl.title%>
+    <%= users_vinyl.vinyl.year %>
+    <%= image_tag users_vinyl.vinyl.photo_url %>
   </label>
 
 <% end %>

--- a/app/views/vinyls/show.html.erb
+++ b/app/views/vinyls/show.html.erb
@@ -15,11 +15,11 @@
 
 <div class="container">
   <h2>Ces personnes ont ce vinyle</h2>
-  <% @collections_vinyls.each do |collection| %>
+  <% @users_vinyls.each do |users_vinyl| %>
     <div class="card p-3 ms-3 d-flex justify-content-between card-user">
       <%= image_tag "https://res.cloudinary.com/dvw6upciw/image/upload/v1670444837/avatar_e5p5i5.webp", :width=>80, :height=>80%>
-      <p><%= collection.user.email %></p>
-      <a><%= link_to 'Je le veux', new_collections_vinyl_exchange_path(collection), class: "btn btn-info" %></a>
+      <p><%= users_vinyl.user.email %></p>
+      <a><%= link_to 'Je le veux', new_users_vinyl_exchange_path(users_vinyl), class: "btn btn-info" %></a>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,14 +6,18 @@ Rails.application.routes.draw do
   root to: "pages#home"
   resources :vinyls, only: [:index, :show] do
     resources :exchanges, only: [:index]
-    resources :collections_vinyls, only: [:create, :new]
+    resources :collections_vinyls, only: [:create, :new] # Ceci sont les anciennes routes, il faudrait prendre ceux de users_vinyls à la place
+    resources :users_vinyls, only: [:create, :new]
   end
 
   resources :collections, only: [:new, :create, :show, :index]
 
-  resources :collections_vinyls, only: [:destroy] do
+  resources :collections_vinyls, only: [:destroy]
+
+  resources :users_vinyls, only: [] do
     resources :exchanges, only: [:new, :create]
   end
+
   resources :wishlists, only: [:destroy]
   resources :chatrooms, only: :show do
     resources :messages, only: :create

--- a/db/migrate/20221212150835_clean_up_database_for_update_preparation.rb
+++ b/db/migrate/20221212150835_clean_up_database_for_update_preparation.rb
@@ -1,0 +1,6 @@
+class CleanUpDatabaseForUpdatePreparation < ActiveRecord::Migration[7.0]
+  def change
+    execute "DELETE FROM exchanges CASCADE;"
+    execute "DELETE FROM collection_vinyls CASCADE;"
+  end
+end

--- a/db/migrate/20221212151601_delete_tables_to_be_updated.rb
+++ b/db/migrate/20221212151601_delete_tables_to_be_updated.rb
@@ -1,0 +1,7 @@
+class DeleteTablesToBeUpdated < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :offered_vinyls
+    drop_table :exchanges
+    drop_table :collection_vinyls
+  end
+end

--- a/db/migrate/20221212152015_create_new_and_updated_tables.rb
+++ b/db/migrate/20221212152015_create_new_and_updated_tables.rb
@@ -1,0 +1,31 @@
+class CreateNewAndUpdatedTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users_vinyls do |t|
+      t.references :user, foreign_key: true
+      t.references :vinyl, foreign_key: true
+      t.boolean :offer_for_trade, null: false, default: false
+      t.timestamps
+    end
+
+    create_table :collections_vinyls do |t|
+      t.references :users_vinyl, foreign_key: true
+      t.references :collection, foreign_key: true
+      t.timestamps
+    end
+
+    create_table :exchanges do |t|
+      t.integer :status, null: false, default: 0
+      t.references :requested_vinyl, foreign_key: { to_table: :users_vinyls }
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+
+    create_table :offered_vinyls do |t|
+      t.references :exchange, foreign_key: true
+      t.references :users_vinyl, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_08_221909) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_12_152015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,16 +55,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_221909) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "collection_vinyls", force: :cascade do |t|
-    t.bigint "vinyl_id", null: false
-    t.bigint "collection_id", null: false
-    t.boolean "offer_for_trade", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["collection_id"], name: "index_collection_vinyls_on_collection_id"
-    t.index ["vinyl_id"], name: "index_collection_vinyls_on_vinyl_id"
-  end
-
   create_table "collections", force: :cascade do |t|
     t.string "name"
     t.bigint "user_id", null: false
@@ -73,12 +63,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_221909) do
     t.index ["user_id"], name: "index_collections_on_user_id"
   end
 
-  create_table "exchanges", force: :cascade do |t|
-    t.integer "status", default: 0, null: false
+  create_table "collections_vinyls", force: :cascade do |t|
+    t.bigint "users_vinyl_id"
+    t.bigint "collection_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
+    t.index ["collection_id"], name: "index_collections_vinyls_on_collection_id"
+    t.index ["users_vinyl_id"], name: "index_collections_vinyls_on_users_vinyl_id"
+  end
+
+  create_table "exchanges", force: :cascade do |t|
+    t.integer "status", default: 0, null: false
     t.bigint "requested_vinyl_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["requested_vinyl_id"], name: "index_exchanges_on_requested_vinyl_id"
     t.index ["user_id"], name: "index_exchanges_on_user_id"
   end
@@ -100,12 +99,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_221909) do
   end
 
   create_table "offered_vinyls", force: :cascade do |t|
-    t.bigint "exchange_id", null: false
-    t.bigint "collection_vinyl_id", null: false
+    t.bigint "exchange_id"
+    t.bigint "users_vinyl_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["collection_vinyl_id"], name: "index_offered_vinyls_on_collection_vinyl_id"
     t.index ["exchange_id"], name: "index_offered_vinyls_on_exchange_id"
+    t.index ["users_vinyl_id"], name: "index_offered_vinyls_on_users_vinyl_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -124,6 +123,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_221909) do
     t.string "nickname"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "users_vinyls", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "vinyl_id"
+    t.boolean "offer_for_trade", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_users_vinyls_on_user_id"
+    t.index ["vinyl_id"], name: "index_users_vinyls_on_vinyl_id"
   end
 
   create_table "vinyls", force: :cascade do |t|
@@ -149,15 +158,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_221909) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "collection_vinyls", "collections"
-  add_foreign_key "collection_vinyls", "vinyls"
   add_foreign_key "collections", "users"
-  add_foreign_key "exchanges", "collection_vinyls", column: "requested_vinyl_id"
+  add_foreign_key "collections_vinyls", "collections"
+  add_foreign_key "collections_vinyls", "users_vinyls"
   add_foreign_key "exchanges", "users"
+  add_foreign_key "exchanges", "users_vinyls", column: "requested_vinyl_id"
   add_foreign_key "messages", "chatrooms"
   add_foreign_key "messages", "users"
-  add_foreign_key "offered_vinyls", "collection_vinyls"
   add_foreign_key "offered_vinyls", "exchanges"
+  add_foreign_key "offered_vinyls", "users_vinyls"
+  add_foreign_key "users_vinyls", "users"
+  add_foreign_key "users_vinyls", "vinyls"
   add_foreign_key "vinyls", "artists"
   add_foreign_key "vinyls", "genres"
   add_foreign_key "wishlists", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,10 +12,13 @@ puts "destroy exchanges..."
 Exchange.destroy_all
 puts "done"
 puts "destroy collectionvinyl..."
-CollectionVinyl.destroy_all
+CollectionsVinyl.destroy_all
 puts "done"
 puts "destroy collection..."
 Collection.destroy_all
+puts "done"
+puts "destroy users_vinyl..."
+UsersVinyl.destroy_all
 puts "done"
 puts "destroy vinyl..."
 Vinyl.destroy_all
@@ -95,10 +98,18 @@ end
 # genre = Genre.create!(name: "Titanic")
 # my_vinyl = Vinyl.create!(title: "Ocean's Eight", photo_url: "https://image.tmdb.org/t/p/original/MvYpKlpFukTivnlBhizGbkAe3v.jpg", year: 2001, artist:artist, genre:genre)
 
-my_collection = Collection.create!(name: "The Shawshank Redemption", user: User.find_by(email: "michelle@gmail.com"))
-CollectionVinyl.create!(vinyl: Vinyl.find_by(title: "Special Sampler"), collection: my_collection, offer_for_trade: true)
-CollectionVinyl.create!(vinyl: Vinyl.find_by(title: "Narm/90"), collection: my_collection, offer_for_trade: true )
-CollectionVinyl.create!(vinyl: Vinyl.find_by(title: "I Don't Wanna Cry"), collection: my_collection, offer_for_trade: true)
+michelle = User.find_by(email: "michelle@gmail.com")
+my_collection = Collection.create!(name: "The Shawshank Redemption", user: michelle)
+
+michelle_users_vinyls = [
+  UsersVinyl.create!(vinyl: Vinyl.find_by(title: "Special Sampler"), user: michelle, offer_for_trade: true),
+  UsersVinyl.create!(vinyl: Vinyl.find_by(title: "Narm/90"), user: michelle, offer_for_trade: true),
+  UsersVinyl.create!(vinyl: Vinyl.find_by(title: "I Don't Wanna Cry"), user: michelle, offer_for_trade: true)
+]
+
+michelle_users_vinyls.each do |users_vinyl|
+  CollectionsVinyl.create!(collection: my_collection, users_vinyl: users_vinyl)
+end
 
 # my_collection1 = Collection.create!(name: "Christophe Bartell", user: User.find_by(email: "edgar@gmail.com"))
 # CollectionVinyl.create!(vinyl: Vinyl.find_by(title: "Step By Step / Vision Of Love"), collection: my_collection1, offer_for_trade: true)

--- a/test/models/users_vinyl_test.rb
+++ b/test/models/users_vinyl_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersVinylTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This is an update to the structure of the database. It adds a new table 'users_vinyls' and reduces the importance of the 'collections_vinyls' table.

Previously, you had to attach the vinyl to a collection in order to use it as part of an exchange. Now, the collections are entirely separated from the exchange process. A user can own a vinyl simply by adding it to the users_vinyls table. It doesn't even need to be part of a collection. From there, the exchange process will simply have to look at what's available in the users_vinyls table. This will simplify virtually all of the features going forward. 

Please note that the functionality to add a vinyl to a list is currently broken. The user flow has changed with the new structure and you will need to discuss what should be the best way to approach it. 

Also, considering the scope of the changes, the pull request has to delete data from the database. After you run `rails db:migrate`, you will need to run `rails db:seed` to get the data back.

For references, here's the old database structure:
![image](https://user-images.githubusercontent.com/43460113/207110692-b27bc545-189e-4b07-b321-26356e54f35f.png)

And here's the updated structure:
![image](https://user-images.githubusercontent.com/43460113/207110840-d594adb8-d6fc-4f34-af1b-ebd4fd0d92e3.png)
